### PR TITLE
Implement ReentrancyGuard for addReaction

### DIFF
--- a/contracts/superclasses/KetlGuarded.sol
+++ b/contracts/superclasses/KetlGuarded.sol
@@ -59,11 +59,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@big-whale-labs/ketl-attestation-token/contracts/KetlAttestation.sol";
 
-contract KetlGuarded is Initializable, OwnableUpgradeable {
+contract KetlGuarded is Initializable, OwnableUpgradeable, ReentrancyGuard {
   KetlAttestation public attestationToken;
   uint public ketlTeamTokenId;
   address public allowedCaller;

--- a/contracts/superclasses/Posts.sol
+++ b/contracts/superclasses/Posts.sol
@@ -322,6 +322,7 @@ contract Posts is KetlGuarded {
     onlyAllowedCaller
     onlyKetlTokenOwners(sender)
     onlyAllowedFeedId(reactionRequest.feedId)
+    nonReentrant
   {
     uint feedId = reactionRequest.feedId;
     uint postId = reactionRequest.postId;


### PR DESCRIPTION
SSIA: Implemented OZ's ReentrancyGuard for `addReaction`:
- `post.author` can reenter via `Address.sendValue` call and potentially drain ETH from `Feeds/Profiles` (inherits `Posts`) contract if `reactionType` changes on every iteration. 